### PR TITLE
Refactor interface and class names for better clarity

### DIFF
--- a/Componentizer.Core/IComponentNavigationAware.cs
+++ b/Componentizer.Core/IComponentNavigationAware.cs
@@ -1,6 +1,6 @@
 ﻿namespace Componentizer;
 
-public interface IComponentNavigatorAware
+public interface IComponentNavigationAware
 {
     /// <summary>
     /// Fires when originally 'pushed' onto the component navigator.

--- a/SampleApp/ComponentA.xaml.cs
+++ b/SampleApp/ComponentA.xaml.cs
@@ -2,9 +2,9 @@
 
 namespace SampleApp;
 
-public partial class ComponentA : ContentView, IComponentNavigatorAware
+public partial class ComponentA : ContentView, IComponentNavigationAware
 {
-    public ComponentA(SampleBViewModel viewModel)
+    public ComponentA(SampleAViewModel viewModel)
     {
         BindingContext = viewModel;
 

--- a/SampleApp/ComponentB.xaml.cs
+++ b/SampleApp/ComponentB.xaml.cs
@@ -2,7 +2,7 @@
 
 namespace SampleApp;
 
-public partial class ComponentB : ContentView, IComponentNavigatorAware, IComponentQueryAttributable
+public partial class ComponentB : ContentView, IComponentNavigationAware, IComponentQueryAttributable
 {
     public ComponentB(SampleBViewModel viewModel)
     {
@@ -13,7 +13,7 @@ public partial class ComponentB : ContentView, IComponentNavigatorAware, ICompon
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
-        System.Console.WriteLine($"Component B: {query}");
+        Console.WriteLine($"Component B: {query}");
     }
 
     public Task NavigatedFromAsync()

--- a/SampleApp/SampleAViewModel.cs
+++ b/SampleApp/SampleAViewModel.cs
@@ -3,12 +3,36 @@ using Componentizer;
 
 namespace SampleApp;
 
-public class SampleAViewModel : ObservableObject
+public class SampleAViewModel : ObservableObject, IComponentNavigationAware
 {
     private readonly IComponentNavigation _componentNavigation;
 
     public SampleAViewModel(IComponentNavigation componentNavigation)
     {
         _componentNavigation = componentNavigation;
+    }
+
+    public Task NavigatedFromAsync()
+    {
+        Console.WriteLine("Navigated From");
+        return Task.CompletedTask;
+    }
+
+    public Task NavigatedToAsync()
+    {
+        Console.WriteLine("Navigated To");
+        return Task.CompletedTask;
+    }
+
+    public Task PoppedAsync()
+    {
+        Console.WriteLine("Popped");
+        return Task.CompletedTask;
+    }
+
+    public Task PoppedBackToAsync()
+    {
+        Console.WriteLine("Popped Back To");
+        return Task.CompletedTask;
     }
 }


### PR DESCRIPTION
- Renamed `IComponentNavigatorAware` to `IComponentNavigationAware`
- Renamed `MauiComponentNavigator` method parameters for consistency
- Updated references to renamed interfaces and classes in the code
- Added new methods to `SampleAViewModel` for navigation events

These changes improve the readability and maintainability of the code by using more descriptive names and ensuring consistency throughout.
